### PR TITLE
positionDropdown should respect input position

### DIFF
--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -203,7 +203,9 @@ class Velge.UI
       @$dropdown.addClass('open')
 
   positionDropdown: (offset = 13) ->
-    @$dropdown.css(top: @$inner.outerHeight() + offset)
+    @$dropdown.css
+      top: @$inner.outerHeight() + offset
+      left: @$input.offset()['left'] - @$wrapper.offset()['left']
 
   closeDropdown: ->
     @$dropdown.removeClass('open')


### PR DESCRIPTION
A user may override CSS so that the input is inline with the tags. If this is the case, the dropdown menu needs to come along for the ride.
