### PR TITLE
Removing a tag should reposition dropdown

### DIFF
--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -187,6 +187,7 @@ class Velge.UI
   removeHighlightedChosen: ->
     $target = @$list.find('.highlighted .name')
     @velge.remChosen(name: $target.text())
+    @positionDropdown()
     @chosenIndex = -1
 
   cycleChoice: (direction) ->


### PR DESCRIPTION
patch-1 included a fix to position the dropdown with respect to the input. This ensures that the UI stays up to date when removal of a tag occurs.
