### PR TITLE
Only set 'left' if we have reason to do so

### DIFF
--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -203,9 +203,15 @@ class Velge.UI
       @$dropdown.addClass('open')
 
   positionDropdown: (offset = 13) ->
+    needsLeft = (@$input.css('display') in ['inline', 'inline-block']) and
+                (@$list.css('display') in ['inline', 'inline-block']) and
+                (@$list.css('float') == 'none')
+    left = 0
+    if needsLeft
+      left = @$input.offset()['left'] - @$wrapper.offset()['left'] 
     @$dropdown.css
       top: @$inner.outerHeight() + offset
-      left: @$input.offset()['left'] - @$wrapper.offset()['left']
+      left: left
 
   closeDropdown: ->
     @$dropdown.removeClass('open')

--- a/velge.js
+++ b/velge.js
@@ -462,11 +462,18 @@
     };
 
     UI.prototype.positionDropdown = function(offset) {
+      var left, needsLeft, _ref, _ref1;
       if (offset == null) {
         offset = 13;
       }
+      needsLeft = ((_ref = this.$input.css('display')) === 'inline' || _ref === 'inline-block') && ((_ref1 = this.$list.css('display')) === 'inline' || _ref1 === 'inline-block') && (this.$list.css('float') === 'none');
+      left = 0;
+      if (needsLeft) {
+        left = this.$input.offset()['left'] - this.$wrapper.offset()['left'];
+      }
       return this.$dropdown.css({
-        top: this.$inner.outerHeight() + offset
+        top: this.$inner.outerHeight() + offset,
+        left: left
       });
     };
 


### PR DESCRIPTION
The default CSS is great, only if a user sets .velge-input and .velge-list to inline or inline-block (and doesn't then force 'block' by declaring 'float') should we set a left property. Otherwise we break the usual case.
