### PR TITLE
Angular, Ember, and React examples

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+.jshintrc
+.travis.yml
+bower.json
+karma.conf.js
+
+example/
+scripts/
+test/
+TODO

--- a/example/angular/README.md
+++ b/example/angular/README.md
@@ -1,0 +1,14 @@
+# Angular + Velge
+
+An example of Velge wrapped in an Angular directive.
+
+## Getting started
+
+`node` and `npm` are required to install dependencies and run the dev server:
+
+```bash
+$ npm install
+$ npm start
+```
+
+Open your browser to `http://localhost:4040` to see the directive in action.

--- a/example/angular/index.html
+++ b/example/angular/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html ng-app="app">
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+    <link rel="stylesheet" href="/node_modules/velge/dist/velge.css" media="screen" charset="utf-8">
+  </head>
+  <body>
+    <h1>Angular + Velge</h1>
+    <velge></velge>
+
+    <script src="/js/bundle.js"></script>
+  </body>
+</html>

--- a/example/angular/js/README.md
+++ b/example/angular/js/README.md
@@ -1,0 +1,2 @@
+Webpack dev server serves the bundle from memory, but if you run `npm run build`
+the bundle file will be output here.

--- a/example/angular/package.json
+++ b/example/angular/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "angular-velge",
+  "version": "1.0.0",
+  "description": "An example of using Velge with Angular",
+  "main": "src/index.js",
+  "scripts": {
+  },
+  "author": "dscout",
+  "license": "MIT",
+  "devDependencies": {
+    "angular": "^1.5.0",
+    "babel-core": "^6.0.0",
+    "babel-loader": "^6.2.3",
+    "babel-preset-es2015": "^6.5.0",
+    "velge": "^1.0.0-alpha",
+    "webpack": "^1.12.13",
+    "webpack-dev-server": "^1.14.1"
+  },
+  "scripts": {
+    "build": "webpack",
+    "start": "webpack-dev-server"
+  }
+}

--- a/example/angular/src/index.js
+++ b/example/angular/src/index.js
@@ -1,0 +1,22 @@
+import angular from 'angular'
+import Velge from 'velge'
+
+angular.module('directives', [])
+  .directive('velge', () => ({
+    restrict: 'E',
+    template: '<div class="velge-container"></div>',
+    link: function(scope, element, attributes) {
+      new Velge(element[0], {
+        choices: [
+          { name: 'macintosh' },
+          { name: 'cortland' }
+        ],
+        chosen: [
+          { name: 'jonagold' },
+          { name: 'snow sweet' }
+        ]
+      })
+    }
+  }))
+
+angular.module('app', ['directives'])

--- a/example/angular/webpack.config.js
+++ b/example/angular/webpack.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    filename: './js/bundle.js'
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        query: {
+          presets: ['es2015']
+        }
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['', '.js']
+  },
+  devServer: {
+    port: 4040
+  }
+};

--- a/example/react/README.md
+++ b/example/react/README.md
@@ -1,0 +1,14 @@
+# React + Velge
+
+Demo app of Velge wrapped in a React component.
+
+## Getting started
+
+Requires `node` and `npm` for installing dependencies and running scripts:
+
+```bash
+$ npm install
+$ npm start
+```
+
+Open your browser to `http://localhost:4040` to see the component in action.

--- a/example/react/index.html
+++ b/example/react/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>React + Velge</title>
+    <link rel="stylesheet" href="/node_modules/velge/dist/velge.css" media="screen" title="no title" charset="utf-8">
+  </head>
+  <body>
+    <div id="app"></div>
+
+    <script src="/js/bundle.js"></script>
+  </body>
+</html>

--- a/example/react/js/README.md
+++ b/example/react/js/README.md
@@ -1,0 +1,2 @@
+Webpack dev server serves the bundle from memory, but if you run `npm run build`
+the bundle file will be output here.

--- a/example/react/package.json
+++ b/example/react/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "react-velge",
+  "version": "1.0.0",
+  "description": "An example of using Velge with React",
+  "main": "src/index.jsx",
+  "scripts": {
+    "build": "webpack",
+    "start": "webpack-dev-server"
+  },
+  "author": "dscout",
+  "license": "MIT",
+  "dependencies": {
+    "babel-core": "^6.0.0",
+    "babel-loader": "^6.2.3",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-react": "^6.5.0",
+    "react": "^0.14.7",
+    "react-dom": "^0.14.7",
+    "velge": "^1.0.0-alpha",
+    "webpack": "^1.12.13",
+    "webpack-dev-server": "^1.14.1"
+  }
+}

--- a/example/react/src/VelgeComponent.jsx
+++ b/example/react/src/VelgeComponent.jsx
@@ -1,0 +1,25 @@
+import React, { Component } from 'react'
+import Velge from 'velge'
+
+class VelgeComponent extends Component {
+  componentDidMount() {
+    this.velge = new Velge(this.container, {
+      choices: [
+        { name: 'macintosh' },
+        { name: 'cortland' }
+      ],
+      chosen: [
+        { name: 'jonagold' },
+        { name: 'snow sweet' }
+      ]
+    })
+  }
+
+  render() {
+    return (
+      <div className="velge-container" ref={ (ref) => this.container = ref } />
+    )
+  }
+}
+
+export default VelgeComponent

--- a/example/react/src/index.jsx
+++ b/example/react/src/index.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { render } from 'react-dom'
+import VelgeComponent from './VelgeComponent'
+
+render(
+  <VelgeComponent />,
+  document.getElementById('app')
+)

--- a/example/react/webpack.config.js
+++ b/example/react/webpack.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  entry: './src/index.jsx',
+  output: {
+    filename: './js/bundle.js'
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        query: {
+          presets: ['es2015', 'react']
+        }
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['', '.js', '.jsx']
+  },
+  devServer: {
+    port: 4040
+  }
+};


### PR DESCRIPTION
Adds examples for the popular frameworks. Also adds a `.npmignore` file to ensure those assets are not included in the published build.
